### PR TITLE
Configure Dependabot cooldown and pnpm minimumReleaseAge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
     groups:
       patch:
         update-types:
@@ -18,3 +20,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
+

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 1440


### PR DESCRIPTION
Configure Dependabot cooldown to 1 day and set pnpm minimumReleaseAge to 1 day (1440 minutes) to align dependencies updates.